### PR TITLE
Fixing blue light lambert term

### DIFF
--- a/ch06/ch06_03_wall-final.html
+++ b/ch06/ch06_03_wall-final.html
@@ -107,7 +107,7 @@
         }
 
         if (lambertTermThree > uCutOff) {
-          Id3 = uDiffuseBlueLight * uMaterialDiffuse * lambertTermTwo;
+          Id3 = uDiffuseBlueLight * uMaterialDiffuse * lambertTermThree;
         }
 
         fragColor = vec4(vec3(Ia + Id1 + Id2 + Id3), 1.0);


### PR DESCRIPTION
Fixing the blue light lambert term, for the `ch06_03_wall-final` example.

old (lambertTermTwo):

![one](https://user-images.githubusercontent.com/2689122/72688286-2282f000-3acb-11ea-81b6-96b039e10288.png)

new (lambertTermThree):

![two](https://user-images.githubusercontent.com/2689122/72688289-2adb2b00-3acb-11ea-8ed3-acc0efd7c43d.png)
