### PR TITLE
Fixing uncaught type error in ch10 example

### DIFF
--- a/ch10/ch10_01_post-process.html
+++ b/ch10/ch10_01_post-process.html
@@ -351,10 +351,10 @@
       post.bind();
 
       // Do any additional post-process shader uniform setup here
-      if (post.uniform.uNoiseSampler) {
+      if (post.uniforms.uNoiseSampler) {
         gl.activeTexture(gl.TEXTURE1);
         gl.bindTexture(gl.TEXTURE_2D, noiseTexture.glTexture);
-        gl.uniform1i(post.uniform.uNoiseSampler, 1);
+        gl.uniform1i(post.uniforms.uNoiseSampler, 1);
       }
 
       // Re-render scene from framebuffer with post process effect


### PR DESCRIPTION
This PR fixes the following uncaught type error in the `ch10_01_post-process` example:

![error](https://user-images.githubusercontent.com/2689122/72945796-8c58ff00-3d42-11ea-9d27-c940048a20af.png)

The PostProcess class defines the following `uniforms` prop, not `uniform`:

```js
this.uniforms = null;
```

Cheers ✌️ 